### PR TITLE
Fix markdown unit tests

### DIFF
--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -137,7 +137,7 @@ func FromMessages(client *slackclient.SlackClient, history *slackclient.HistoryR
 		if includeSpeakerHeader {
 			fmt.Fprintf(b, "> **%s** at %s\n",
 				username,
-				messageTime.Format("2006-01-02 15:04"))
+				messageTime.UTC().Format("2006-01-02 15:04"))
 		}
 		fmt.Fprintf(b, ">\n")
 

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -137,7 +137,7 @@ func FromMessages(client *slackclient.SlackClient, history *slackclient.HistoryR
 		if includeSpeakerHeader {
 			fmt.Fprintf(b, "> **%s** at %s\n",
 				username,
-				messageTime.UTC().Format("2006-01-02 15:04"))
+				messageTime.In(client.GetLocation()).Format("2006-01-02 15:04 MST"))
 		}
 		fmt.Fprintf(b, ">\n")
 

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -13,7 +13,7 @@ import (
 func TestFromMessagesCombinesAdjacentMessagesFromSameUser(t *testing.T) {
 	httpclient.Client = &mocks.MockClient{}
 	mocks.MockSuccessfulAuthResponse()
-	client, err := slackclient.New("test", nil)
+	client, err := slackclient.Null("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 1969-12-31 18:02
+	expected := `> **cheshire137** at 1970-01-01 00:02
 >
 > hello
 >
@@ -40,7 +40,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameUser(t *testing.T) {
 func TestFromMessagesCombinesAdjacentMessagesFromSameBot(t *testing.T) {
 	httpclient.Client = &mocks.MockClient{}
 	mocks.MockSuccessfulAuthResponse()
-	client, err := slackclient.New("test", nil)
+	client, err := slackclient.Null("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameBot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **bot bot123** at 1969-12-31 18:02
+	expected := `> **bot bot123** at 1970-01-01 00:02
 >
 > hello
 >
@@ -66,7 +66,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameBot(t *testing.T) {
 func TestFromMessagesSeparatesMessagesFromSameUserWhenFarApartInTime(t *testing.T) {
 	httpclient.Client = &mocks.MockClient{}
 	mocks.MockSuccessfulAuthResponse()
-	client, err := slackclient.New("test", nil)
+	client, err := slackclient.Null("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,11 +80,11 @@ func TestFromMessagesSeparatesMessagesFromSameUserWhenFarApartInTime(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 2023-03-17 08:12
+	expected := `> **cheshire137** at 2023-03-17 13:12
 >
 > hello
 
-> **cheshire137** at 2023-03-17 09:42
+> **cheshire137** at 2023-03-17 14:42
 >
 > second message`
 	if expected != strings.TrimSpace(actual) {
@@ -95,7 +95,7 @@ func TestFromMessagesSeparatesMessagesFromSameUserWhenFarApartInTime(t *testing.
 func TestFromMessagesSeparatesMessagesFromSameUserWhenNotAdjacent(t *testing.T) {
 	httpclient.Client = &mocks.MockClient{}
 	mocks.MockSuccessfulAuthResponse()
-	client, err := slackclient.New("test", nil)
+	client, err := slackclient.Null("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,15 +113,15 @@ func TestFromMessagesSeparatesMessagesFromSameUserWhenNotAdjacent(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 1969-12-31 18:02
+	expected := `> **cheshire137** at 1970-01-01 00:02
 >
 > first!
 
-> **octokatherine** at 1969-12-31 18:02
+> **octokatherine** at 1970-01-01 00:02
 >
 > Message the Second
 
-> **cheshire137** at 1969-12-31 18:02
+> **cheshire137** at 1970-01-01 00:02
 >
 > third message`
 	if expected != strings.TrimSpace(actual) {

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -27,7 +27,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 1970-01-01 00:02
+	expected := `> **cheshire137** at 1970-01-01 00:02 UTC
 >
 > hello
 >
@@ -53,7 +53,7 @@ func TestFromMessagesCombinesAdjacentMessagesFromSameBot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **bot bot123** at 1970-01-01 00:02
+	expected := `> **bot bot123** at 1970-01-01 00:02 UTC
 >
 > hello
 >
@@ -80,11 +80,11 @@ func TestFromMessagesSeparatesMessagesFromSameUserWhenFarApartInTime(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 2023-03-17 13:12
+	expected := `> **cheshire137** at 2023-03-17 13:12 UTC
 >
 > hello
 
-> **cheshire137** at 2023-03-17 14:42
+> **cheshire137** at 2023-03-17 14:42 UTC
 >
 > second message`
 	if expected != strings.TrimSpace(actual) {
@@ -113,15 +113,15 @@ func TestFromMessagesSeparatesMessagesFromSameUserWhenNotAdjacent(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `> **cheshire137** at 1970-01-01 00:02
+	expected := `> **cheshire137** at 1970-01-01 00:02 UTC
 >
 > first!
 
-> **octokatherine** at 1970-01-01 00:02
+> **octokatherine** at 1970-01-01 00:02 UTC
 >
 > Message the Second
 
-> **cheshire137** at 1970-01-01 00:02
+> **cheshire137** at 1970-01-01 00:02 UTC
 >
 > third message`
 	if expected != strings.TrimSpace(actual) {

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -83,6 +83,7 @@ type SlackClient struct {
 	auth      *SlackAuth
 	cache     Cache
 	log       *log.Logger
+	tz        *time.Location
 }
 
 func New(team string, log *log.Logger) (*SlackClient, error) {
@@ -106,6 +107,7 @@ func New(team string, log *log.Logger) (*SlackClient, error) {
 		team:      team,
 		auth:      auth,
 		log:       log,
+		tz:        time.Now().Location(),
 	}
 
 	err = c.loadCache()
@@ -126,6 +128,7 @@ func Null(team string) (*SlackClient, error) {
 			Token: "null",
 		},
 		cachePath: cacheFile.Name(),
+		tz:        time.UTC,
 	}, nil
 }
 
@@ -395,4 +398,8 @@ func (c *SlackClient) UsernameForID(id string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no user with id %q", id)
+}
+
+func (c *SlackClient) GetLocation() *time.Location {
+	return c.tz
 }

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -112,6 +112,23 @@ func New(team string, log *log.Logger) (*SlackClient, error) {
 	return c, err
 }
 
+// Null produces a SlackClient suitable for testing that does not try to load
+// the Slack token or cookies from disk, and starts with an empty cache.
+func Null(team string) (*SlackClient, error) {
+	cacheFile, err := os.CreateTemp("", "gh-slack-cache")
+	if err != nil {
+		return nil, err
+	}
+
+	return &SlackClient{
+		team: team,
+		auth: &SlackAuth{
+			Token: "null",
+		},
+		cachePath: cacheFile.Name(),
+	}, nil
+}
+
 func (c *SlackClient) UsernameForMessage(message Message) (string, error) {
 	if message.User != "" {
 		return c.UsernameForID(message.User)


### PR DESCRIPTION
1. Introduce a test SlackClient constructor that doesn't try to load cookies from disk.
2. Adjust the time output to be UTC and adjust the tests accordingly. I am not sure if this is actually a good idea, but this was another reason why the tests were failing for me locally. I'd appreciate feedback/thoughts on this.